### PR TITLE
Add dependency for polylines in gemspec

### DIFF
--- a/google_directions.gemspec
+++ b/google_directions.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "google_directions"
-  s.version = "0.1.6.2"
+  s.version = "0.1.6.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/google_directions.gemspec
+++ b/google_directions.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<nokogiri>, [">= 1.4.1"])
   end
+  s.add_dependency(%q<polylines>, [">= 0.3.0"])
 end

--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -66,12 +66,12 @@ class GoogleDirections
     end
   end
 
-  def distance_in_miles
+  def distance_in_miles(decimal_places: 0)
     if @status != "OK"
       distance_in_miles = 0
     else
       meters = distance
-      distance_in_miles = (meters.to_f / 1610.22).round
+      distance_in_miles = (meters.to_f / 1610.22).round(decimal_places)
       distance_in_miles
     end
   end

--- a/test/unit/google_directions_test.rb
+++ b/test/unit/google_directions_test.rb
@@ -9,6 +9,7 @@ class GoogleDirectionsTest < Test::Unit::TestCase
     dest = "499 Gordonsville Highway, 38563"
     directions = GoogleDirections.new(orig, dest)
     assert_equal(4, directions.distance_in_miles)
+    assert_equal(3.6, directions.distance_in_miles(decimal_places: 1))
     assert_equal(5, directions.drive_time_in_minutes)
     assert_equal('http://maps.googleapis.com/maps/api/directions/xml?language=en&alternative=true&sensor=false&mode=driving&origin=121+Gordonsville+Highway%2C+37030&destination=499+Gordonsville+Highway%2C+38563', directions.xml_call)
     # end_location > lat


### PR DESCRIPTION
Now that polylines is used by google_directions, bundling google_directions prevents app startup if polylines wasn't already installed.

(I didn't bump the version number; don't know if that was really needed here)